### PR TITLE
proof-of-concept for #116

### DIFF
--- a/src/main/java/de/funfried/netbeans/plugins/external/formatter/java/eclipse/ui/EclipseJavaFormatterOptionsPanel.java
+++ b/src/main/java/de/funfried/netbeans/plugins/external/formatter/java/eclipse/ui/EclipseJavaFormatterOptionsPanel.java
@@ -45,6 +45,7 @@ import de.funfried.netbeans.plugins.external.formatter.eclipse.xml.ConfigReader;
 import de.funfried.netbeans.plugins.external.formatter.exceptions.ConfigReadException;
 import de.funfried.netbeans.plugins.external.formatter.java.eclipse.EclipseJavaFormatterSettings;
 import de.funfried.netbeans.plugins.external.formatter.ui.options.AbstractFormatterOptionsPanel;
+import de.funfried.netbeans.plugins.external.formatter.ui.options.Settings;
 
 /**
  *
@@ -53,6 +54,8 @@ import de.funfried.netbeans.plugins.external.formatter.ui.options.AbstractFormat
 public class EclipseJavaFormatterOptionsPanel extends AbstractFormatterOptionsPanel {
 	/** {@link Logger} of this class. */
 	private static final Logger log = Logger.getLogger(EclipseJavaFormatterOptionsPanel.class.getName());
+
+	private String projectDirectory = null;
 
 	/** Creates new form {@link EclipseJavaFormatterOptionsPanel}. */
 	public EclipseJavaFormatterOptionsPanel() {
@@ -338,6 +341,9 @@ public class EclipseJavaFormatterOptionsPanel extends AbstractFormatterOptionsPa
 		String eclipseLineFeed = preferences.get(EclipseJavaFormatterSettings.LINEFEED, "");
 		String sourceLevel = preferences.get(EclipseJavaFormatterSettings.SOURCELEVEL, "");
 
+		projectDirectory = preferences.get(Settings.PROJECT_DIRECTORY, null);
+		preferences.remove(Settings.PROJECT_DIRECTORY);
+
 		loadEclipseFormatterFileForPreview(eclipseFormatterLocation, eclipseFormatterProfile);
 
 		cbUseProjectPref.setSelected(useProjectPrefs);
@@ -359,6 +365,10 @@ public class EclipseJavaFormatterOptionsPanel extends AbstractFormatterOptionsPa
 
 	private void loadEclipseFormatterFileForPreview(String formatterFile, String activeProfile) {
 		formatterLocField.setText(formatterFile);
+
+		if(formatterFile.startsWith(EclipseJavaFormatterSettings.PROJECT_DIR_MARKER) && projectDirectory != null) {
+			formatterFile = formatterFile.replace(EclipseJavaFormatterSettings.PROJECT_DIR_MARKER, projectDirectory);
+		}
 		final File file = new File(formatterFile);
 
 		cbProfile.setEnabled(false);
@@ -430,6 +440,10 @@ public class EclipseJavaFormatterOptionsPanel extends AbstractFormatterOptionsPa
 		boolean isXML = EclipseJavaFormatterSettings.isXMLConfigurationFile(fileName);
 		boolean isEPF = EclipseJavaFormatterSettings.isWorkspaceMechanicFile(fileName);
 		boolean isProjectSetting = EclipseJavaFormatterSettings.isProjectSetting(fileName);
+		
+		if(fileName.startsWith(EclipseJavaFormatterSettings.PROJECT_DIR_MARKER) && projectDirectory != null) {
+			fileName = fileName.replace(EclipseJavaFormatterSettings.PROJECT_DIR_MARKER, projectDirectory);
+		}
 
 		if (!new File(fileName).exists() || (!isXML && !isEPF && !isProjectSetting) || cbProfile.getSelectedIndex() < 0) {
 			errorLabel.setText("Invalid file. Please enter a valid configuration file.");

--- a/src/main/java/de/funfried/netbeans/plugins/external/formatter/ui/customizer/ExternalFormatterCustomizerTab.java
+++ b/src/main/java/de/funfried/netbeans/plugins/external/formatter/ui/customizer/ExternalFormatterCustomizerTab.java
@@ -29,6 +29,7 @@ import org.openide.util.WeakListeners;
 
 import de.funfried.netbeans.plugins.external.formatter.ui.Icons;
 import de.funfried.netbeans.plugins.external.formatter.ui.options.ExternalFormatterPanel;
+import de.funfried.netbeans.plugins.external.formatter.ui.options.Settings;
 
 /**
  * {@link ProjectCustomizer.CompositeCategoryProvider} implementation for project
@@ -67,9 +68,11 @@ public class ExternalFormatterCustomizerTab implements ProjectCustomizer.Composi
 	 */
 	@Override
 	public JComponent createComponent(final Category category, final Lookup lkp) {
-		Preferences projectPreferences = ProjectUtils.getPreferences(lkp.lookup(Project.class), ExternalFormatterPanel.class, true);
+		Project project = lkp.lookup(Project.class);
+		Preferences projectPreferences = ProjectUtils.getPreferences(project, ExternalFormatterPanel.class, true);
+		projectPreferences.put(Settings.PROJECT_DIRECTORY, project.getProjectDirectory().getPath());
 		final ExternalFormatterPanel configPanel = new ExternalFormatterPanel(projectPreferences, true);
-		final ProjectSpecificSettingsPanel projectSpecificSettingsPanel = new ProjectSpecificSettingsPanel(configPanel, projectPreferences);
+		final ProjectSpecificSettingsPanel projectSpecificSettingsPanel =  new ProjectSpecificSettingsPanel(configPanel, projectPreferences);
 		configPanel.load();
 		projectSpecificSettingsPanel.load();
 

--- a/src/main/java/de/funfried/netbeans/plugins/external/formatter/ui/options/Settings.java
+++ b/src/main/java/de/funfried/netbeans/plugins/external/formatter/ui/options/Settings.java
@@ -70,6 +70,9 @@ public class Settings {
 	/** Property key which defines whether or not to use project specific settings instead of global formatter settings. */
 	public static final String USE_PROJECT_SETTINGS = "useProjectSettings";
 
+	/** Property key for current project directory in case of project specific configuration. */
+	public static final String PROJECT_DIRECTORY = "projectDirectory";
+
 	/**
 	 * Private contructor because of static methods only.
 	 */


### PR DESCRIPTION
With the following issues/questions:
* using the preferences for transporting the project directory is most likely not a good idea
  * adding an new parameter to `FormatterOptionsPanel#load(Preferences)` method could be an option (would make the feature much more generic, currently only focus on the Eclipse formatter)
    * or perhaps replace `Preferences` with something like `FormatterOptions` that contains the `Preferences` and project directory among potentially others (would be more future-proof)
* there are some UI problems after entering the relative path, sometimes pressing ENTER key worked, sometimes the red error message about invalid file did not go away (re-opening the dialog was needed)
  * unfortunately I have no clue how to fix that... didn't touch Swing code for years
* no unit tests
  * static methods in `EclipseJavaFormatterSettings` would have required a bit more refactoring (what I wanted to avoid, goal was to have as little changes as possible)
  * no idea what to do test in the ui part