### PR TITLE
#178

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.netbeans.api</groupId>
+			<artifactId>org-openide-modules</artifactId>
+			<version>${netbeans.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>${commons-lang.version}</version>

--- a/src/main/java/de/funfried/netbeans/plugins/external/formatter/Installer.java
+++ b/src/main/java/de/funfried/netbeans/plugins/external/formatter/Installer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 bahlef.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ * Contributors:
+ * bahlef - initial API and implementation and/or initial documentation
+ */
+
+package de.funfried.netbeans.plugins.external.formatter;
+
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
+import org.openide.modules.ModuleInstall;
+
+public class Installer extends ModuleInstall {
+	private static final long serialVersionUID = -4271835537575254490L;
+
+	@Override
+	public void validate() throws IllegalStateException {
+		super.validate();
+
+		if (!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_11)) {
+			throw new IllegalStateException("This plugin only works with Java 11+, but NetBeans is running with Java " + SystemUtils.JAVA_VERSION);
+		}
+	}
+}

--- a/src/main/nbm/manifest.mf
+++ b/src/main/nbm/manifest.mf
@@ -1,3 +1,4 @@
 Manifest-Version: 1.0
+OpenIDE-Module-Install: de/funfried/netbeans/plugins/external/formatter/Installer.class
 OpenIDE-Module-Layer: de/funfried/netbeans/plugins/external/formatter/layer.xml
 OpenIDE-Module-Localizing-Bundle: de/funfried/netbeans/plugins/external/formatter/Bundle.properties


### PR DESCRIPTION
Added a module installer to the plugin, so NetBeans will try to call the plugin when starting up and fail to call the installer if NetBeans runs below Java 11, otherwise it would cause issues in the editor during runtime when NetBeans is running with Java 8 instead of Java 11 (which is required by this plugin and its dependencies)